### PR TITLE
fix: 同一天有多个运动时选中地图路线显示错误问题

### DIFF
--- a/scripts/gpxtrackposter/grid_drawer.py
+++ b/scripts/gpxtrackposter/grid_drawer.py
@@ -74,5 +74,5 @@ class GridDrawer(TracksDrawer):
                 stroke_linejoin="round",
                 stroke_linecap="round",
             )
-            polyline.set_desc(title=date_title)
+            polyline.set_desc(title=date_title, desc=tr.start_time_local)
             dr.add(polyline)

--- a/scripts/gpxtrackposter/grid_drawer.py
+++ b/scripts/gpxtrackposter/grid_drawer.py
@@ -74,5 +74,5 @@ class GridDrawer(TracksDrawer):
                 stroke_linejoin="round",
                 stroke_linecap="round",
             )
-            polyline.set_desc(title=date_title, desc=tr.start_time_local)
+            polyline.set_desc(title=date_title, desc=tr.run_id)
             dr.add(polyline)

--- a/scripts/gpxtrackposter/track.py
+++ b/scripts/gpxtrackposter/track.py
@@ -116,6 +116,7 @@ class Track:
             summary_polyline = filter_out(activity.summary_polyline)
         polyline_data = polyline.decode(summary_polyline) if summary_polyline else []
         self.polylines = [[s2.LatLng.from_degrees(p[0], p[1]) for p in polyline_data]]
+        self.run_id = activity.run_id
 
     def bbox(self):
         """Compute the smallest rectangle that contains the entire track (border box)."""

--- a/src/components/RunTable/RunRow.jsx
+++ b/src/components/RunTable/RunRow.jsx
@@ -14,7 +14,7 @@ const RunRow = ({ elementIndex, locateActivity, run, runIndex, setRunIndex }) =>
   const handleClick = (e) => {
     if (runIndex === elementIndex) return;
     setRunIndex(elementIndex);
-    locateActivity([run.id]);
+    locateActivity([run.run_id]);
   };
 
   return (

--- a/src/components/RunTable/RunRow.jsx
+++ b/src/components/RunTable/RunRow.jsx
@@ -14,7 +14,7 @@ const RunRow = ({ elementIndex, locateActivity, run, runIndex, setRunIndex }) =>
   const handleClick = (e) => {
     if (runIndex === elementIndex) return;
     setRunIndex(elementIndex);
-    locateActivity(run.start_date_local.slice(0, 10));
+    locateActivity([run.id]);
   };
 
   return (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -77,7 +77,7 @@ const Index = () => {
   const locateActivity = (runIds) => {
     const ids = new Set(runIds)
 
-    const selectedRuns = runs.filter((r) => ids.has(r.id));
+    const selectedRuns = runs.filter((r) => ids.has(r.run_id));
 
     if (!selectedRuns.length) {
       return;
@@ -133,13 +133,12 @@ const Index = () => {
 
         // 点击的是 github 样式 svg
         if (tagName === 'rect' &&
-        parseFloat(target.getAttribute('width')) === 2.6 &&
-        parseFloat(target.getAttribute('height')) === 2.6 &&
-        target.getAttribute('fill') !== '#444444') {
+          parseFloat(target.getAttribute('width')) === 2.6 &&
+          parseFloat(target.getAttribute('height')) === 2.6 &&
+          target.getAttribute('fill') !== '#444444') {
 
           const [runDate] = target.innerHTML.match(/\d{4}-\d{1,2}-\d{1,2}/) || [`${+thisYear + 1}`];
-
-          const runIDsOnDate = runs.filter((r) => r.start_date_local.slice(0, 10) === runDate).map((r) => r.id)
+          const runIDsOnDate = runs.filter((r) => r.start_date_local.slice(0, 10) === runDate).map((r) => r.run_id)
           if (!runIDsOnDate.length) {
             return
           }
@@ -148,12 +147,11 @@ const Index = () => {
         } else if (tagName === 'polyline') { // 点击的是路线缩略图
           const desc = target.getElementsByTagName('desc')[0]
           if (!desc) { return }
-          const detailDate = desc.innerHTML
-          const runIDsOnDate = runs.filter((r) => r.start_date_local === detailDate).map((r) => r.id)
-          if (!runIDsOnDate.length) {
+          const run_id = Number(desc.innerHTML)
+          if (!run_id) {
             return
           }
-          locateActivity(runIDsOnDate)
+          locateActivity([run_id])
         }
       }
     })

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -74,22 +74,22 @@ const Index = () => {
     changeByItem(type, 'Type', filterTypeRuns, false);
   };
 
-  const locateActivity = (runDate) => {
-    const activitiesOnDate = runs.filter((r) => r.start_date_local.slice(0, 10) === runDate);
+  const locateActivity = (runIds) => {
+    const ids = new Set(runIds)
 
-    if (!activitiesOnDate.length) {
+    const selectedRuns = runs.filter((r) => ids.has(r.id));
+
+    if (!selectedRuns.length) {
       return;
     }
 
-    const sortedActivities = activitiesOnDate.sort((a, b) => b.distance - a.distance);
-    const info = sortedActivities[0];
+    const lastRun = selectedRuns.sort(sortDateFunc)[0];
 
-    if (!info) {
+    if (!lastRun) {
       return;
     }
-
-    setGeoData(geoJsonForRuns([info]));
-    setTitle(titleForShow(info));
+    setGeoData(geoJsonForRuns(selectedRuns));
+    setTitle(titleForShow(lastRun));
     clearInterval(intervalId);
     scrollToMap();
   };
@@ -131,15 +131,29 @@ const Index = () => {
       if (target) {
         const tagName = target.tagName.toLowerCase()
 
-        if ((tagName === 'rect' &&
-          parseFloat(target.getAttribute('width')) === 2.6 &&
-          parseFloat(target.getAttribute('height')) === 2.6 &&
-          target.getAttribute('fill') !== '#444444'
-        ) || (
-            tagName === 'polyline'
-          )) {
+        // 点击的是 github 样式 svg
+        if (tagName === 'rect' &&
+        parseFloat(target.getAttribute('width')) === 2.6 &&
+        parseFloat(target.getAttribute('height')) === 2.6 &&
+        target.getAttribute('fill') !== '#444444') {
+
           const [runDate] = target.innerHTML.match(/\d{4}-\d{1,2}-\d{1,2}/) || [`${+thisYear + 1}`];
-          locateActivity(runDate)
+
+          const runIDsOnDate = runs.filter((r) => r.start_date_local.slice(0, 10) === runDate).map((r) => r.id)
+          if (!runIDsOnDate.length) {
+            return
+          }
+          locateActivity(runIDsOnDate)
+
+        } else if (tagName === 'polyline') { // 点击的是路线缩略图
+          const desc = target.getElementsByTagName('desc')[0]
+          if (!desc) { return }
+          const detailDate = desc.innerHTML
+          const runIDsOnDate = runs.filter((r) => r.start_date_local === detailDate).map((r) => r.id)
+          if (!runIDsOnDate.length) {
+            return
+          }
+          locateActivity(runIDsOnDate)
         }
       }
     })


### PR DESCRIPTION
我看着改了点，对项目不熟悉，你看下这样会有问题不。

### 修改
修改成通过 id 数组来定位选择的运动纪录，用数组是因为日期选择时可能有多条纪录。对应情况的处理：
- 列表选择时：直接传入选中的 id
- 缩略图选择时：在 polyline 标签中新增 desc 标签（desc 标签不影响网页显示），内容为具体时间。然后通过具体时间找到对应 id（一天内不同运动具体时间应该不同）
- 日期方块选中时：根据日期过滤出当天的所有运动

### 优化
- 之前选择日期是只是显示距离最长的一条运动路线，没法看到其他的。现在改成显示当天的所有路线，地图上的文本显示为当天最后一条纪录。