### PR TITLE
add min-width:100px to '.runRow td:first-child' class

### DIFF
--- a/src/components/RunTable/style.module.scss
+++ b/src/components/RunTable/style.module.scss
@@ -34,6 +34,7 @@
 
     &:first-child {
       text-align: left;
+      min-width: 100px;
     }
   }
 


### PR DESCRIPTION
给 `.runTable` class 增加了 `min-width: 480px;`

防止中文运动名称的情况下（如，苏州太湖东山徒步），手机端 `runTable` 运动名称断行严重。
