### PR TITLE
Add Austria in `standardizeCountryName`

### DIFF
--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -21,6 +21,9 @@ const standardizeCountryName = (country: string): string => {
   }
   if (country.includes('所罗门群岛')) {
     return '所罗门群岛';
+  }
+  if (country.includes('奧地利')) {
+    return '奥地利';
   } else {
     return country;
   }


### PR DESCRIPTION
在我的数据中，经测试加上下面这行才会在全球的地图中显示奥地利：

```ts
if (country.includes('奧地利')) {
    return '奥地利';
  }
```

请注意第一个是繁体的 `奧地利`。不清楚是什么原因，请 review 一下，谢谢！