### PR TITLE
fix:IGNORE_START_END_RANGE =0时仍会截断轨迹首尾两点 #61

### DIFF
--- a/run_page/polyline_processor.py
+++ b/run_page/polyline_processor.py
@@ -70,6 +70,9 @@ def range_hiding(
 
 
 def start_end_hiding(polyline: List[Tuple[float]], distance: int) -> List[Tuple[float]]:
+    if distance <= 0:
+        return polyline
+
     start_index, end_index = 0, len(polyline) - 1
 
     starting_distance = 0


### PR DESCRIPTION
修复 #61 
现在Action不会截断首尾点了：
<img width="510" height="207" alt="image" src="https://github.com/user-attachments/assets/14878547-8bc2-4a3d-9407-eecd068c84bd" />
对比修复前：
<img width="503" height="162" alt="image" src="https://github.com/user-attachments/assets/76e9b9b0-d7ec-4e96-97a7-d8870e02d5f3" />
